### PR TITLE
LIBRARIES-1490 - Update image to 8.17.3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       # Checkout the git repository
       - name: checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,13 +15,14 @@ jobs:
     steps:
       # Setup java environment
       - name: setup-java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 11
 
       # Checkout the git repository
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GPR_TOKEN }}
@@ -33,7 +34,7 @@ jobs:
 
       # Setup/load GitHub Actions caching for external dependencies, in this case especially for Maven
       - name: caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -58,7 +59,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.OS_SONAR_TOKEN }}
         run: |
           export SONAR_ORGANIZATION=$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)
-          mvn sonar:sonar \
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
             -Dsonar.host.url=${SONAR_HOST} \
             -Dsonar.login=${SONAR_TOKEN} \
             -Dsonar.organization=${SONAR_ORGANIZATION} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,9 @@ jobs:
     steps:
       # Setup java environment
       - name: setup-java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 11
           server-id: ossrh
           server-username: OSSRH_USERNAME
@@ -38,7 +39,7 @@ jobs:
 
       # Checkout the git repository
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GPR_TOKEN }}
@@ -50,7 +51,7 @@ jobs:
 
       # Setup GitHub Actions caching for external dependencies, in this case especially for Maven
       - name: caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -71,7 +72,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.OS_SONAR_TOKEN }}
         run: |
           export SONAR_ORGANIZATION=$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)
-          mvn sonar:sonar \
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
             -Dsonar.host.url=${SONAR_HOST} \
             -Dsonar.login=${SONAR_TOKEN} \
             -Dsonar.organization=${SONAR_ORGANIZATION} \
@@ -81,7 +82,7 @@ jobs:
       # Get the current project version from POM
       - name: get-project-version
         id: get_project_version
-        uses: avides/actions-project-version-check@v1
+        uses: avides/actions-project-version-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file-to-check: pom.xml
@@ -93,19 +94,16 @@ jobs:
         env:
           PROJECT_VERSION: ${{ steps.get_project_version.outputs.version }}
         run: |
-          echo ::set-output name=gitcommitmessage::$(git log --no-merges -1 --oneline)
+          echo "gitcommitmessage=$(git log --no-merges -1 --oneline)" >> $GITHUB_OUTPUT
           if [[ "$PROJECT_VERSION" == *"SNAPSHOT"* || "$PROJECT_VERSION" == *"RC"* ]]; then
-            echo ::set-output name=isprerelease::true
+            echo "isprerelease=true" >> $GITHUB_OUTPUT
           fi
 
       # Create and publish GitHub Release tag
       - name: github-release
-        uses: actions/create-release@v1
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GPR_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.GPR_TOKEN }}
           tag_name: ${{ steps.get_project_version.outputs.version }}
-          release_name: ${{ steps.get_project_version.outputs.version }}
           body: ${{ steps.setup_github_release.outputs.gitcommitmessage }}
           prerelease: ${{ steps.setup_github_release.outputs.isprerelease }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       # Checkout the git repository
       - name: checkout

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   review:
     timeout-minutes: 30
-    
+
     runs-on: ubuntu-latest
 
     concurrency:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,13 +36,7 @@ jobs:
       - name: post-checkout
         run: git fetch --prune --unshallow
 
-      # Update GitHub Action configuration if necessary
-      - name: action-configuration-autoupdate
-        uses: avides/actions-action-configuration-autoupdate@v2
-        with:
-          token: ${{ secrets.GPR_TOKEN }}
-          actions-configuration-files: os-java-library/nightly.yml,os-java-library/release.yml,os-java-library/review.yml
-          source-repository: ${{ secrets.ACTIONS_CONFIG_AUTOUPDATE_REPO }}
+
 
       # Push updated GitHub Actions configuration if necessary
       - uses: stefanzweifel/git-auto-commit-action@v5
@@ -119,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export SONAR_ORGANIZATION=$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.host.url=${SONAR_HOST} \
             -Dsonar.login=${SONAR_TOKEN} \
             -Dsonar.organization=${SONAR_ORGANIZATION} \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,8 +36,6 @@ jobs:
       - name: post-checkout
         run: git fetch --prune --unshallow
 
-
-
       # Push updated GitHub Actions configuration if necessary
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
@@ -113,7 +111,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export SONAR_ORGANIZATION=$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
             -Dsonar.host.url=${SONAR_HOST} \
             -Dsonar.login=${SONAR_TOKEN} \
             -Dsonar.organization=${SONAR_ORGANIZATION} \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,25 +9,24 @@ on:
 jobs:
   review:
     timeout-minutes: 30
-
+    
     runs-on: ubuntu-latest
 
-    steps:
-      # Cancels previous run for this branch that have a different commit id (SHA)
-      - name: cancel-previous-run
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
+    steps:
       # Setup java environment
       - name: setup-java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 11
 
       # Checkout the git repository
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GPR_TOKEN }}
@@ -39,14 +38,14 @@ jobs:
 
       # Update GitHub Action configuration if necessary
       - name: action-configuration-autoupdate
-        uses: avides/actions-action-configuration-autoupdate@v1
+        uses: avides/actions-action-configuration-autoupdate@v2
         with:
           token: ${{ secrets.GPR_TOKEN }}
           actions-configuration-files: os-java-library/nightly.yml,os-java-library/release.yml,os-java-library/review.yml
           source-repository: ${{ secrets.ACTIONS_CONFIG_AUTOUPDATE_REPO }}
 
       # Push updated GitHub Actions configuration if necessary
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: .github/workflows/*.yml
           commit_user_name: ${{ secrets.ACTIONS_CONFIG_AUTOUPDATE_USER }}
@@ -56,34 +55,45 @@ jobs:
 
       # Verify project version is updated
       - name: project-version-check
-        uses: avides/actions-project-version-check@v1
+        uses: avides/actions-project-version-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file-to-check: pom.xml
           additional-files-to-check: README.md
 
-      # Check if documentation reminder comment is already given
-      - name: find-documentation-reminder-comment
-        uses: peter-evans/find-comment@v1
-        id: find_documentation_reminder_comment
+      # Check if reminder comment is already given
+      - name: find-reminder-comment
+        uses: peter-evans/find-comment@v3
+        id: find_reminder_comment
         with:
           issue-number: ${{ github.event.number }}
           body-includes: "Confluence/GitHub documentation added or updated?"
 
-      # Add documentation reminder comment if not given
-      - name: documentation-reminder-comment
-        uses: jungwinter/comment@v1
+      # Add reminder comment if not given
+      - name: reminder-comment
+        uses: peter-evans/create-or-update-comment@v4
         id: create
-        if: ${{ steps.find_documentation_reminder_comment.outputs.comment-id == 0 }}
+        if: ${{ steps.find_reminder_comment.outputs.comment-id == 0 }}
         with:
-          type: create
-          body: 'Confluence/GitHub documentation added or updated?'
-          issue_number: ${{ github.event.number }}
+          body: |
+            - Confluence/GitHub documentation added or updated?
+              - Diff-Links as response added?
+                - [ ] Not necessary
+                - [ ] Added
+
+            - [Breaking-Change](<https://avides.atlassian.net/wiki/spaces/ITENT/pages/211498/Wann+habe+ich+einen+breaking+change>) present?
+              - Necessary deployment adjustments added as a comment (Jira-Ticket)?
+                - [ ] Not necessary
+                - [ ] Added
+              - Necessary rollback adjustments added as a comment (Jira-Ticket)?
+                - [ ] Not necessary
+                - [ ] Added
+          issue-number: ${{ github.event.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup/load GitHub Actions caching for external dependencies, in this case especially for Maven
       - name: caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -109,7 +119,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export SONAR_ORGANIZATION=$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)
-          mvn sonar:sonar \
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
             -Dsonar.host.url=${SONAR_HOST} \
             -Dsonar.login=${SONAR_TOKEN} \
             -Dsonar.organization=${SONAR_ORGANIZATION} \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   review:
     timeout-minutes: 30
-
+    
     runs-on: ubuntu-latest
 
     concurrency:
@@ -35,6 +35,14 @@ jobs:
       # Execute some necessary git commands to get more repository informations
       - name: post-checkout
         run: git fetch --prune --unshallow
+
+      # Update GitHub Action configuration if necessary
+      - name: action-configuration-autoupdate
+        uses: avides/actions-action-configuration-autoupdate@v2
+        with:
+          token: ${{ secrets.GPR_TOKEN }}
+          actions-configuration-files: os-java-library/nightly.yml,os-java-library/release.yml,os-java-library/review.yml
+          source-repository: ${{ secrets.ACTIONS_CONFIG_AUTOUPDATE_REPO }}
 
       # Push updated GitHub Actions configuration if necessary
       - uses: stefanzweifel/git-auto-commit-action@v5

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <dependency>
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-elasticsearch</artifactId>
-  <version>1.4.0</version>
+  <version>2.0.0</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -25,7 +25,7 @@ Properties consumed (in `bootstrap.properties`):
 
 - `embedded.container.elasticsearch.enabled` (default is `true`)
 - `embedded.container.elasticsearch.startup-timeout` (default is `30`)
-- `embedded.container.elasticsearch.docker-image` (default is `docker.elastic.co/elasticsearch/elasticsearch:7.17.9`)
+- `embedded.container.elasticsearch.docker-image` (default is `docker.elastic.co/elasticsearch/elasticsearch:8.17.3`)
 - `embedded.container.elasticsearch.http-port` (default is `9200`)
 - `embedded.container.elasticsearch.transport-host` (default is `9300`)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-elasticsearch</artifactId>
-  <version>1.4.0</version>
+  <version>2.0.0</version>
 
   <name>springtainer-elasticsearch</name>
   <description>Elasticsearch test-container</description>
@@ -63,7 +63,7 @@
     <lombok.version>1.18.26</lombok.version>
     <junit.version>4.13.2</junit.version>
     <slf4j-api.version>1.7.36</slf4j-api.version>
-    <spring-data-elasticsearch.version>4.3.10</spring-data-elasticsearch.version>
+    <spring-data-elasticsearch.version>4.4.18</spring-data-elasticsearch.version>
     <jackson-core.version>2.13.4</jackson-core.version>
     <!-- Testing -->
     <jacoco.version>0.8.8</jacoco.version>

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchProperties.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchProperties.java
@@ -22,6 +22,6 @@ public class ElasticsearchProperties extends AbstractEmbeddedContainerProperties
 
     public ElasticsearchProperties()
     {
-        setDockerImage("docker.elastic.co/elasticsearch/elasticsearch:7.17.9");
+        setDockerImage("docker.elastic.co/elasticsearch/elasticsearch:8.17.3");
     }
 }

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
@@ -50,7 +50,6 @@ public class EmbeddedElasticsearchContainerAutoConfiguration
             List<String> envs = new ArrayList<>();
             envs.add("discovery.type=single-node");
             envs.add("xpack.security.enabled=false");
-            envs.add("xpack.monitoring.enabled=false");
             envs.add("xpack.ml.enabled=false");
             envs.add("xpack.graph.enabled=false");
             envs.add("xpack.watcher.enabled=false");

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,7 +17,7 @@
 			"name": "embedded.container.elasticsearch.docker-image",
 			"type": "java.lang.String",
 			"description": "Docker-image",
-			"defaultValue": "docker.elastic.co/elasticsearch/elasticsearch:7.17.9"
+			"defaultValue": "docker.elastic.co/elasticsearch/elasticsearch:8.17.3"
 		},
 		{
 			"name": "embedded.container.elasticsearch.http-port",

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
@@ -15,6 +15,7 @@ import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.ReflectionUtils;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DockerClientBuilder;
@@ -53,7 +54,14 @@ public abstract class AbstractIT
         {
             var builder = RestClient.builder(new HttpHost(host, port));
             var client = new RestHighLevelClient(builder);
-
+            ReflectionUtils.doWithFields(RestHighLevelClient.class, field ->
+            {
+                if (field.getName().equals("useAPICompatibility"))
+                {
+                    ReflectionUtils.makeAccessible(field);
+                    field.setBoolean(client, true);
+                }
+            });
             return new ElasticsearchRestTemplate(client);
         }
     }

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchPropertiesTest.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchPropertiesTest.java
@@ -13,7 +13,7 @@ public class ElasticsearchPropertiesTest
         var properties = new ElasticsearchProperties();
         assertTrue(properties.isEnabled());
         assertEquals(30, properties.getStartupTimeout());
-        assertEquals("docker.elastic.co/elasticsearch/elasticsearch:7.17.9", properties.getDockerImage());
+        assertEquals("docker.elastic.co/elasticsearch/elasticsearch:8.17.3", properties.getDockerImage());
 
         assertEquals(9200, properties.getHttpPort());
         assertEquals(9300, properties.getTransportPort());


### PR DESCRIPTION
Breaking change: The es version has been updated from 7.17.9 to 8.17.3. Spring data elasticsearch only works via [useAPICompatibility-Mode](https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-api-compatibility.html#request-rest-api-compatibility)!