### PR TITLE
springtainer-elasticsearch: Update auf Spring Boot 4.1.X und Java 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
+      - spring-boot-4-migration
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
-      - spring-boot-4-migration
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <dependency>
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-elasticsearch</artifactId>
-  <version>3.0.0</version>
+  <version>4.0.0-RC1</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-scm-provider-gitexe.version>1.11.3</maven-scm-provider-gitexe.version>
+    <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,9 @@
     <!-- Common -->
     <spring-boot.version>4.1.0</spring-boot.version>
     <springtainer-common.version>3.0.0-RC1</springtainer-common.version>
+    <!-- Held at the 8.x line to match the Elasticsearch 8 servers this container is used against: a 9.x client
+         sends compatible-with=9, which an 8.x server rejects with media_type_header_exception. -->
+    <elasticsearch-client.version>8.19.19</elasticsearch-client.version>
     <lombok.version>1.18.46</lombok.version>
     <!-- Other -->
     <!-- Testing -->
@@ -119,6 +122,7 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
+      <version>${elasticsearch-client.version}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -128,8 +132,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>co.elastic.clients</groupId>
-      <artifactId>elasticsearch-rest5-client</artifactId>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>${elasticsearch-client.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,46 +105,15 @@
     
     <!-- Other -->
     <dependency>
-      <groupId>org.springframework.data</groupId>
-      <artifactId>spring-data-elasticsearch</artifactId>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
       <version>${elasticsearch-client.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
       <version>${elasticsearch-client.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,6 @@
     <!-- Common -->
     <spring-boot.version>4.1.0</spring-boot.version>
     <springtainer-common.version>3.0.0-RC1</springtainer-common.version>
-    <!-- Held at the 8.x line to match the Elasticsearch 8 servers this container is used against: a 9.x client
-         sends compatible-with=9, which an 8.x server rejects with media_type_header_exception. -->
-    <elasticsearch-client.version>8.19.19</elasticsearch-client.version>
     <lombok.version>1.18.46</lombok.version>
     <!-- Other -->
     <!-- Testing -->
@@ -107,13 +104,11 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
-      <version>${elasticsearch-client.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <version>${elasticsearch-client.version}</version>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-rest5-client</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-elasticsearch</artifactId>
-  <version>3.0.0</version>
+  <version>4.0.0-RC1</version>
 
   <name>springtainer-elasticsearch</name>
   <description>Elasticsearch test-container</description>
@@ -40,7 +40,7 @@
     <!-- Build -->
     <maven.build.timestamp.format>dd.MM.yyyy HH:mm</maven.build.timestamp.format>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -53,8 +53,8 @@
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->
-    <spring-boot.version>3.5.16</spring-boot.version>
-    <springtainer-common.version>2.0.0</springtainer-common.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
+    <springtainer-common.version>3.0.0-RC1</springtainer-common.version>
     <lombok.version>1.18.46</lombok.version>
     <!-- Other -->
     <!-- Testing -->
@@ -128,6 +128,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-rest5-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
@@ -188,6 +193,7 @@
         <configuration>
           <release>${java.version}</release>
           <parameters>true</parameters>
+          <proc>full</proc>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchProperties.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchProperties.java
@@ -22,6 +22,6 @@ public class ElasticsearchProperties extends AbstractEmbeddedContainerProperties
 
     public ElasticsearchProperties()
     {
-        setDockerImage("docker.elastic.co/elasticsearch/elasticsearch:9.4.2");
+        setDockerImage("docker.elastic.co/elasticsearch/elasticsearch:8.19.18");
     }
 }

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchProperties.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchProperties.java
@@ -22,6 +22,6 @@ public class ElasticsearchProperties extends AbstractEmbeddedContainerProperties
 
     public ElasticsearchProperties()
     {
-        setDockerImage("docker.elastic.co/elasticsearch/elasticsearch:8.19.18");
+        setDockerImage("docker.elastic.co/elasticsearch/elasticsearch:9.4.2");
     }
 }

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
@@ -7,8 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -23,8 +22,9 @@ import com.avides.springboot.springtainer.common.container.EmbeddedContainer;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.HealthStatus;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 
 import lombok.SneakyThrows;
 
@@ -75,9 +75,9 @@ public class EmbeddedElasticsearchContainerAutoConfiguration
         @Override
         protected boolean isContainerReady(ElasticsearchProperties properties)
         {
-            try (var restClient = RestClient.builder(new HttpHost(getContainerHost(), getContainerPort(properties.getHttpPort()))).build())
+            try (var restClient = Rest5Client.builder(new HttpHost(getContainerHost(), getContainerPort(properties.getHttpPort()))).build())
             {
-                var transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+                var transport = new Rest5ClientTransport(restClient, new Jackson3JsonpMapper());
                 var client = new ElasticsearchClient(transport);
                 var status = client.cluster().health().status();
                 return status == HealthStatus.Green || status == HealthStatus.Yellow;

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
@@ -7,8 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -24,7 +23,8 @@ import com.avides.springboot.springtainer.common.container.EmbeddedContainer;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.HealthStatus;
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 
 import lombok.SneakyThrows;
 
@@ -75,9 +75,9 @@ public class EmbeddedElasticsearchContainerAutoConfiguration
         @Override
         protected boolean isContainerReady(ElasticsearchProperties properties)
         {
-            try (var restClient = RestClient.builder(new HttpHost(getContainerHost(), getContainerPort(properties.getHttpPort()))).build())
+            try (var restClient = Rest5Client.builder(new HttpHost(getContainerHost(), getContainerPort(properties.getHttpPort()))).build())
             {
-                var transport = new RestClientTransport(restClient, new Jackson3JsonpMapper());
+                var transport = new Rest5ClientTransport(restClient, new Jackson3JsonpMapper());
                 var client = new ElasticsearchClient(transport);
                 var status = client.cluster().health().status();
                 return status == HealthStatus.Green || status == HealthStatus.Yellow;

--- a/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
+++ b/src/main/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfiguration.java
@@ -7,7 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hc.core5.http.HttpHost;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -23,8 +24,7 @@ import com.avides.springboot.springtainer.common.container.EmbeddedContainer;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.HealthStatus;
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
-import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
-import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 
 import lombok.SneakyThrows;
 
@@ -75,9 +75,9 @@ public class EmbeddedElasticsearchContainerAutoConfiguration
         @Override
         protected boolean isContainerReady(ElasticsearchProperties properties)
         {
-            try (var restClient = Rest5Client.builder(new HttpHost(getContainerHost(), getContainerPort(properties.getHttpPort()))).build())
+            try (var restClient = RestClient.builder(new HttpHost(getContainerHost(), getContainerPort(properties.getHttpPort()))).build())
             {
-                var transport = new Rest5ClientTransport(restClient, new Jackson3JsonpMapper());
+                var transport = new RestClientTransport(restClient, new Jackson3JsonpMapper());
                 var client = new ElasticsearchClient(transport);
                 var status = client.cluster().health().status();
                 return status == HealthStatus.Green || status == HealthStatus.Yellow;

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,7 +17,7 @@
 			"name": "embedded.container.elasticsearch.docker-image",
 			"type": "java.lang.String",
 			"description": "Docker-image",
-			"defaultValue": "docker.elastic.co/elasticsearch/elasticsearch:9.4.2"
+			"defaultValue": "docker.elastic.co/elasticsearch/elasticsearch:8.19.18"
 		},
 		{
 			"name": "embedded.container.elasticsearch.http-port",

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,7 +17,7 @@
 			"name": "embedded.container.elasticsearch.docker-image",
 			"type": "java.lang.String",
 			"description": "Docker-image",
-			"defaultValue": "docker.elastic.co/elasticsearch/elasticsearch:8.19.18"
+			"defaultValue": "docker.elastic.co/elasticsearch/elasticsearch:9.4.2"
 		},
 		{
 			"name": "embedded.container.elasticsearch.http-port",

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
@@ -1,7 +1,6 @@
 package com.avides.springboot.springtainer.elasticsearch;
 
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchClients;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
@@ -19,6 +17,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.avides.springboot.springtainer.common.util.DockerClients;
 import com.github.dockerjava.api.DockerClient;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = AbstractIT.EsConfiguration.class)
@@ -52,8 +55,8 @@ public abstract class AbstractIT
         @Bean
         public ElasticsearchOperations elasticsearchOperations()
         {
-            var restClient = RestClient.builder(new HttpHost(host, port)).build();
-            var client = ElasticsearchClients.createImperative(restClient);
+            var restClient = Rest5Client.builder(new HttpHost(host, port)).build();
+            var client = new ElasticsearchClient(new Rest5ClientTransport(restClient, new Jackson3JsonpMapper()));
             return new ElasticsearchTemplate(client);
         }
     }

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
@@ -1,5 +1,7 @@
 package com.avides.springboot.springtainer.elasticsearch;
 
+import java.io.IOException;
+
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,10 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
-import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -23,24 +21,39 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = AbstractIT.EsConfiguration.class)
 @DirtiesContext
 public abstract class AbstractIT
 {
+    protected static final String INDEX = "test";
+
     protected DockerClient dockerClient = DockerClients.build();
 
     @Autowired
     protected ConfigurableEnvironment environment;
 
     @Autowired
-    protected ElasticsearchOperations elasticsearchOperations;
+    protected ElasticsearchClient elasticsearchClient;
 
-    protected void index(IndexQuery indexQuery, IndexCoordinates indexCoordinates)
+    /**
+     * Indexes the given document and refreshes the index, so that it is immediately visible to searches.
+     */
+    protected void index(String id, Object document) throws IOException
     {
-        elasticsearchOperations.index(indexQuery, indexCoordinates);
-        elasticsearchOperations.indexOps(indexCoordinates).refresh();
+        elasticsearchClient.index(request -> request.index(INDEX).id(id).document(document));
+        refresh();
+    }
+
+    protected void delete(String id) throws IOException
+    {
+        elasticsearchClient.delete(request -> request.index(INDEX).id(id));
+        refresh();
+    }
+
+    protected void refresh() throws IOException
+    {
+        elasticsearchClient.indices().refresh(request -> request.index(INDEX));
     }
 
     @Configuration
@@ -54,11 +67,10 @@ public abstract class AbstractIT
 
         @SuppressWarnings("resource")
         @Bean
-        public ElasticsearchOperations elasticsearchOperations()
+        public ElasticsearchClient elasticsearchClient()
         {
             var restClient = RestClient.builder(new HttpHost(host, port)).build();
-            var client = new ElasticsearchClient(new RestClientTransport(restClient, new Jackson3JsonpMapper()));
-            return new ElasticsearchTemplate(client);
+            return new ElasticsearchClient(new RestClientTransport(restClient, new Jackson3JsonpMapper()));
         }
     }
 }

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
@@ -1,6 +1,7 @@
 package com.avides.springboot.springtainer.elasticsearch;
 
-import org.apache.hc.core5.http.HttpHost;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,8 +21,8 @@ import com.github.dockerjava.api.DockerClient;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
-import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
-import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = AbstractIT.EsConfiguration.class)
@@ -55,8 +56,8 @@ public abstract class AbstractIT
         @Bean
         public ElasticsearchOperations elasticsearchOperations()
         {
-            var restClient = Rest5Client.builder(new HttpHost(host, port)).build();
-            var client = new ElasticsearchClient(new Rest5ClientTransport(restClient, new Jackson3JsonpMapper()));
+            var restClient = RestClient.builder(new HttpHost(host, port)).build();
+            var client = new ElasticsearchClient(new RestClientTransport(restClient, new Jackson3JsonpMapper()));
             return new ElasticsearchTemplate(client);
         }
     }

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/AbstractIT.java
@@ -2,8 +2,7 @@ package com.avides.springboot.springtainer.elasticsearch;
 
 import java.io.IOException;
 
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,7 +18,8 @@ import com.github.dockerjava.api.DockerClient;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = AbstractIT.EsConfiguration.class)
@@ -69,8 +69,8 @@ public abstract class AbstractIT
         @Bean
         public ElasticsearchClient elasticsearchClient()
         {
-            var restClient = RestClient.builder(new HttpHost(host, port)).build();
-            return new ElasticsearchClient(new RestClientTransport(restClient, new Jackson3JsonpMapper()));
+            var restClient = Rest5Client.builder(new HttpHost(host, port)).build();
+            return new ElasticsearchClient(new Rest5ClientTransport(restClient, new Jackson3JsonpMapper()));
         }
     }
 }

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchPropertiesTest.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchPropertiesTest.java
@@ -13,7 +13,7 @@ public class ElasticsearchPropertiesTest
         var properties = new ElasticsearchProperties();
         assertTrue(properties.isEnabled());
         assertEquals(30, properties.getStartupTimeout());
-        assertEquals("docker.elastic.co/elasticsearch/elasticsearch:9.4.2", properties.getDockerImage());
+        assertEquals("docker.elastic.co/elasticsearch/elasticsearch:8.19.18", properties.getDockerImage());
 
         assertEquals(9200, properties.getHttpPort());
         assertEquals(9300, properties.getTransportPort());

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchPropertiesTest.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/ElasticsearchPropertiesTest.java
@@ -13,7 +13,7 @@ public class ElasticsearchPropertiesTest
         var properties = new ElasticsearchProperties();
         assertTrue(properties.isEnabled());
         assertEquals(30, properties.getStartupTimeout());
-        assertEquals("docker.elastic.co/elasticsearch/elasticsearch:8.19.18", properties.getDockerImage());
+        assertEquals("docker.elastic.co/elasticsearch/elasticsearch:9.4.2", properties.getDockerImage());
 
         assertEquals(9200, properties.getHttpPort());
         assertEquals(9300, properties.getTransportPort());

--- a/src/test/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfigurationIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/elasticsearch/EmbeddedElasticsearchContainerAutoConfigurationIT.java
@@ -1,14 +1,12 @@
 package com.avides.springboot.springtainer.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.core.query.IndexQuery;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,27 +31,50 @@ public class EmbeddedElasticsearchContainerAutoConfigurationIT extends AbstractI
     }
 
     @Test
-    public void testCrud()
+    public void testCrud() throws IOException
     {
         // create
-        var indexQuery = new IndexQuery();
-        indexQuery.setId("key1");
-        indexQuery.setObject(new DummyDocument("key1", "value1"));
-        index(indexQuery, elasticsearchOperations.getIndexCoordinatesFor(DummyDocument.class));
-
-        // read
-        assertThat(elasticsearchOperations.get("key1", DummyDocument.class).getValue()).isEqualTo("value1");
+        index("key1", new DummyDocument("key1", "value1"));
+        assertThat(get("key1").getValue()).isEqualTo("value1");
 
         // update
-        var updateQuery = new IndexQuery();
-        updateQuery.setId("key1");
-        updateQuery.setObject(new DummyDocument("key1", "value2"));
-        index(updateQuery, elasticsearchOperations.getIndexCoordinatesFor(DummyDocument.class));
-        assertThat(elasticsearchOperations.get("key1", DummyDocument.class).getValue()).isEqualTo("value2");
+        index("key1", new DummyDocument("key1", "value2"));
+        assertThat(get("key1").getValue()).isEqualTo("value2");
 
         // delete
-        elasticsearchOperations.delete("key1", elasticsearchOperations.getIndexCoordinatesFor(DummyDocument.class));
-        assertNull(elasticsearchOperations.get("key1", DummyDocument.class));
+        delete("key1");
+        assertThat(elasticsearchClient.get(request -> request.index(INDEX).id("key1"), DummyDocument.class).found()).isFalse();
+    }
+
+    /**
+     * Searching exercises query serialization and hit deserialization, which is the part of the client/server
+     * contract most sensitive to a version mismatch between the two. Get-by-id keeps working across such a
+     * mismatch, so it does not cover this on its own.
+     */
+    @Test
+    public void testSearch() throws IOException
+    {
+        index("key1", new DummyDocument("key1", "matching"));
+        index("key2", new DummyDocument("key2", "matching"));
+        index("key3", new DummyDocument("key3", "different"));
+
+        var response = elasticsearchClient.search(
+                request -> request.index(INDEX).query(query -> query.match(match -> match.field("value").query("matching"))),
+                DummyDocument.class);
+
+        assertThat(response.hits().total().value()).isEqualTo(2);
+        assertThat(response.hits().hits())
+                .extracting(hit -> hit.source().getKey())
+                .containsExactlyInAnyOrder("key1", "key2");
+
+        delete("key1");
+        delete("key2");
+        delete("key3");
+    }
+
+    private DummyDocument get(String id) throws IOException
+    {
+        return elasticsearchClient.get(request -> request.index(INDEX).id(id), DummyDocument.class).source();
     }
 
     @Configuration
@@ -63,14 +84,12 @@ public class EmbeddedElasticsearchContainerAutoConfigurationIT extends AbstractI
         // nothing
     }
 
-    @Document(indexName = "test")
     @NoArgsConstructor
     @AllArgsConstructor
     @Setter
     @Getter
     public static class DummyDocument
     {
-        @Id
         private String key;
 
         private String value;


### PR DESCRIPTION
Hebt `springtainer-elasticsearch` auf Spring Boot 4.1.0 und Java 25. Zielversion **4.0.0-RC1**.

### Merge-Reihenfolge

Die CI dieses PRs bleibt so lange rot, bis die folgenden Libraries gemergt und released sind - ihre RC-Artefakte liegen bisher nur lokal:

- `springtainer-common`

Ticket: https://avides.atlassian.net/browse/LIBRARIES-1752
Epic: https://avides.atlassian.net/browse/ITGS-470